### PR TITLE
[feat][#66] cancel court bookings when removing courts from a game

### DIFF
--- a/.claude/skills/management/SKILL.md
+++ b/.claude/skills/management/SKILL.md
@@ -92,7 +92,8 @@ CourtBookingRepository — Save(ctx, *models.CourtBooking),
                    MarkCanceled(ctx, matchID) — soft-delete: sets canceled_at = NOW(),
                    MarkCanceledByVenueAndDate(ctx, venueID, gameDate) — bulk soft-delete all active rows for venue+date,
                    HasActiveByCredentialID(ctx, credentialID) bool,
-                   HasActiveByVenueID(ctx, venueID) bool
+                   HasActiveByVenueID(ctx, venueID) bool,
+                   GetActiveByVenueDateAndLabels(ctx, venueID int64, gameDate time.Time, labels []string) — active rows whose court_label matches one of the given labels; used by the manual court-removal flow
 AutoBookingResultRepository — Save(ctx, venueID int64, gameDate time.Time, gameTime, courts string, courtsCount int) (int64, error) — returns the saved row ID (used by AutoBookingJob to call SetGameID immediately),
                    GetByVenueAndDate(ctx, venueID int64, date time.Time) []*models.AutoBookingResult,
                    GetByVenueAndDateAndTime(ctx, venueID int64, date time.Time, gameTime string) *models.AutoBookingResult — nil if not yet booked,
@@ -130,7 +131,12 @@ POST   /api/v1/games                               — createGame
 GET    /api/v1/games                               — listGames (query: chatIDs)
 GET    /api/v1/games/{id}                          — getGame
 PATCH  /api/v1/games/{id}/message-id               — updateMessageID
-PATCH  /api/v1/games/{id}/courts                   — updateCourts
+PATCH  /api/v1/games/{id}/courts                   — updateCourts; when body contains cancel_bookings=true,
+                                                     calls RemoveCourtsAndCancelBookings instead: 204 on full
+                                                     success, 200+JSON {canceled:[],failed:[{court,reason}]}
+                                                     on partial failure
+GET    /api/v1/games/{id}/active-court-bookings    — listActiveCourtBookings; query: courts (comma-sep labels);
+                                                     returns [{court_label,game_time,match_id}] for active bookings
 POST   /api/v1/games/{id}/publish                  — publishGame; body: actor_telegram_id, actor_display;
                                                      404 if not found, 409 if already published, 502 on Telegram send failure
 
@@ -238,7 +244,19 @@ The canonical publication primitive. Sends the game announcement to the group ch
 - On `gameRepo.UpdateMessageID` failure: deletes the orphaned Telegram message, then returns error.
 - `actorTgID == 0` → audit records `actor_kind = system`; non-zero → `actor_kind = user`.
 
-`NewGameService` signature (9 args): `gameRepo, venueRepo, participationRepo, guestRepo, groupRepo GameRepository…, auditSvc *AuditService, api TelegramAPI, defaultLoc *time.Location, logger *slog.Logger`.
+`NewGameService` signature (13 args): `gameRepo, venueRepo, participationRepo, guestRepo, groupRepo GameRepository…, auditSvc *AuditService, api TelegramAPI, defaultLoc *time.Location, logger *slog.Logger, courtBookingRepo CourtBookingRepository, bookingClient BookingServiceClient, credService *VenueCredentialService, autoBookingResultRepo AutoBookingResultRepository`.
+
+**`GameService.ListActiveCourtBookings(ctx, gameID int64, courts []string) ([]CourtBookingInfo, error)`**
+
+Returns slim booking info (`CourtBookingInfo{CourtLabel, GameTime, MatchID string}`) for active bookings whose `court_label` matches one of the provided labels. Uses `activeBookingsByLabels` for time-slot scoping. Returns nil/empty when booking infrastructure is absent or the game has no venue.
+
+**`GameService.RemoveCourtsAndCancelBookings(ctx, gameID int64, newCourts string) (canceledLabels []string, cancelErrors []CourtCancelError, err error)`**
+
+Computes a multiset diff of removed courts, looks up active bookings via `activeBookingsByLabels`, cancels each via `BookingServiceClient.CancelMatch` with per-entry credentials (fetched via `VenueCredentialService.GetDecryptedByID`), records audit, then always persists `newCourts` regardless of cancellation failures. Returns `CourtCancelError{CourtLabel, Err}` slices for partial failures. The DB update always runs — partial failures do not block the court list change.
+
+**`GameService.activeBookingsByLabels(ctx, game, labels)` (private)**
+
+Time-slot-aware booking lookup. Calls `autoBookingResultRepo.GetByGameID(game.ID)` to find `game_time`. If non-empty: `GetByVenueAndDateAndTime` + app-level label filter. Otherwise: `GetActiveByVenueDateAndLabels`. Prevents cross-session false matches when a venue hosts multiple sessions on the same date.
 
 ### Scheduler (`service/scheduler.go`)
 

--- a/.claude/skills/telegram/SKILL.md
+++ b/.claude/skills/telegram/SKILL.md
@@ -30,8 +30,9 @@ cmd/telegram/
 │   ├── game_manage_handlers.go  — handleManage, handleManageShowPlayers/Guests, handleManageEditCourts,
 │   │                              handleManageClose, handleManageKickPlayer/Guest,
 │   │                              handleManageCourtsToggle, handleManageCourtsConfirm,
+│   │                              handleManageCourtsCancelConfirm, handleManageCourtsCancelAbort,
 │   │                              handleManagePublish (Publish button for unpublished games),
-│   │                              processCourtsEdit
+│   │                              courtsBeingRemoved, renderCourtCancelPrompt, processCourtsEdit
 │   ├── newgame_handlers.go  — /newGame wizard: handleNewGameDate/Group/Venue/CourtToggle/
 │   │                          CourtConfirm/TimeSlot/TimeCustom, processNewGameWizard,
 │   │                          buildDateSelectionKeyboard, renderCourtPickKeyboard, renderTimeSlotKeyboard
@@ -70,8 +71,9 @@ type Bot struct {
     pendingVenueGameDaysEdit      sync.Map  // chatID → *venueGameDaysEditState
     pendingVenuePreferredTimeEdit sync.Map  // chatID → *venuePreferredTimeEditState
     pendingGroupVenuePick         sync.Map  // chatID → *groupVenuePickState
-    pendingVenueCredAdd           sync.Map  // chatID → *venueCredWizard
-    handlerSem                    chan struct{}  // semaphore, maxConcurrentHandlers=50
+    pendingVenueCredAdd                sync.Map  // chatID → *venueCredWizard
+    pendingManageCourtsCancelPrompt    sync.Map  // chatID → *manageCourtsCancelPromptState
+    handlerSem                         chan struct{}  // semaphore, maxConcurrentHandlers=50
     callbackRouter                map[string]callbackHandler
 }
 ```
@@ -120,6 +122,8 @@ All callback actions:
 join, skip, guest_add, guest_remove
 manage, manage_players, manage_guests, manage_courts, manage_close
 manage_kick, manage_kick_guest, manage_court_toggle, manage_court_confirm
+manage_courts_cancel_confirm (confirm cancel-booking-and-remove after pre-flight prompt)
+manage_courts_cancel_abort   (go back to court toggle keyboard, restoring prior selection)
 publish_game (sends unpublished game to group via POST /api/v1/games/{id}/publish)
 select_group (3-part: originChatID:originMsgID:groupID)
 ng_date, ng_group, ng_venue, ng_court_toggle, ng_court_confirm
@@ -191,6 +195,21 @@ The "🔑 Credentials" button in the venue edit menu is only shown when `venue.A
 ### Courts Edit (`game_manage_handlers.go`)
 State: `pendingManageCourtsToggle sync.Map` (chatID → `*manageCourtsToggleState`)
 
+### Courts Cancel Prompt (`game_manage_handlers.go`)
+State: `pendingManageCourtsCancelPrompt sync.Map` (chatID → `*manageCourtsCancelPromptState`)
+
+```go
+type manageCourtsCancelPromptState struct {
+    gameID       int64
+    groupID      int64
+    newCourts    string    // the confirmed court selection being applied
+    bookedLabels []string  // court labels that have active bookings
+    venueCourts  []string  // all venue courts (for restoring toggle keyboard on abort)
+}
+```
+
+Populated by `handleManageCourtsConfirm` when `ListActiveCourtBookings` returns active bookings for removed courts. Cleared by both confirm and abort handlers.
+
 ---
 
 ## Business logic flows
@@ -249,6 +268,21 @@ Works in private chat only. Group @mentions redirected to private chat. At least
 - If game has a venue with courts configured → inline court-toggle keyboard (same ✓ UX). Pre-selects current courts. Confirm → `manage_court_confirm:<gameID>`.
 - If game has no venue → falls back to free-text input.
 
+**Booking cancellation pre-flight (two-step confirmation):**
+
+When admin confirms court removal (`manage_court_confirm`), the handler:
+1. Computes which courts are being removed via `courtsBeingRemoved` (multiset diff).
+2. Calls `client.ListActiveCourtBookings(gameID, removedCourts)` to check for active Eversports bookings.
+3. On error → answers callback, shows `MsgSomethingWentWrong`, returns (blocking — no silent fallthrough).
+4. On active bookings found → stores `*manageCourtsCancelPromptState` in `pendingManageCourtsCancelPrompt`, answers callback, calls `renderCourtCancelPrompt` which edits the message with:
+   - Text: `MsgCourtCancelPromptSingle` / `MsgCourtCancelPromptMulti` (lists booked court labels)
+   - Buttons: `BtnCourtCancelConfirm` (`manage_courts_cancel_confirm:<gameID>`) + `BtnCourtCancelAbort` (`manage_courts_cancel_abort:<gameID>`)
+5. On no active bookings → proceeds directly to `UpdateCourts` as before (no prompt).
+
+`handleManageCourtsCancelConfirm`: re-validates admin via `isAdminInGroup`, clears both pending states, calls `UpdateCourtsAndCancelBookings`. Partial failures → `MsgCourtCancelPartial`; full success → `MsgCourtCancelSuccess`.
+
+`handleManageCourtsCancelAbort`: clears cancel prompt state, restores `pendingManageCourtsToggle` pre-seeded from `state.newCourts`, calls `renderManageCourtsKeyboard`.
+
 ### Button Click Flow (join / skip / guest)
 
 1. Parse callback data (`action:game_id`, e.g. `join:123`).
@@ -283,7 +317,9 @@ Works in private chat only. Group @mentions redirected to private chat. At least
 ```
 Games:          CreateGame, GetGameByID, UpdateMessageID, UpdateCourts,
                 GetUpcomingGamesByChatIDs, GetNextGameForTelegramUser,
-                PublishGame(ctx, gameID, actorTgID int64, actorDisplay string) (*models.Game, error)
+                PublishGame(ctx, gameID, actorTgID int64, actorDisplay string) (*models.Game, error),
+                ListActiveCourtBookings(ctx, gameID int64, courts []string) ([]CourtBookingInfo, error),
+                UpdateCourtsAndCancelBookings(ctx, gameID, groupID int64, newCourts, actorDisplay string, actorTgID int64) (canceledLabels []string, failed []CancelFailure, err error)
 Participations: Join, Skip, AddGuest, RemoveGuest, GetParticipations, GetGuests,
                 KickPlayer, KickGuestByID
 Groups:         UpsertGroup, RemoveGroup, GetGroups, GroupExists, GetGroupByID,
@@ -293,6 +329,10 @@ VenueCredentials: AddVenueCredential(ctx, venueID, groupID, login, password, pri
                   ListVenueCredentials, DeleteVenueCredential, ListVenueCredentialPriorities
 Scheduler:      TriggerScheduledEvent
 ```
+
+**Client-side types** (defined in `client.go`, used by handlers):
+- `CourtBookingInfo{CourtLabel, GameTime, MatchID string}` — returned by `ListActiveCourtBookings`
+- `CancelFailure{Court, Reason string}` — element of `failed` slice returned by `UpdateCourtsAndCancelBookings` on partial failure; mapped from HTTP 200+JSON body `{canceled:[], failed:[{court,reason}]}`
 
 **Error propagation:** `client.go` defines `HTTPError{StatusCode int, Message string}` — a typed error returned by `parseErrorBody`. Handlers use `errors.As(err, &httpErr)` to branch on specific HTTP status codes (e.g. 409 Conflict) before falling through to generic error messages. Always return `*HTTPError` from `parseErrorBody` for new error cases; do not wrap with `fmt.Errorf`.
 

--- a/cmd/management/api/games.go
+++ b/cmd/management/api/games.go
@@ -116,7 +116,8 @@ func (h *Handler) updateMessageID(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// updateCourts handles PATCH /api/v1/games/{id}/courts
+// updateCourts handles PATCH /api/v1/games/{id}/courts.
+// When cancel_bookings=true, active Eversports bookings for removed courts are canceled first.
 func (h *Handler) updateCourts(w http.ResponseWriter, r *http.Request) {
 	id, err := parseID(r.PathValue("id"))
 	if err != nil {
@@ -128,11 +129,46 @@ func (h *Handler) updateCourts(w http.ResponseWriter, r *http.Request) {
 		GroupID         int64  `json:"group_id"`
 		ActorTelegramID int64  `json:"actor_telegram_id"`
 		ActorDisplay    string `json:"actor_display"`
+		CancelBookings  bool   `json:"cancel_bookings"`
 	}
 	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
+
+	if req.CancelBookings {
+		canceledLabels, cancelErrors, svcErr := h.gameService.RemoveCourtsAndCancelBookings(r.Context(), id, req.Courts)
+		if svcErr != nil {
+			h.logger.Error("updateCourts (cancel)", "err", svcErr, "id", id)
+			writeError(w, http.StatusInternalServerError, svcErr.Error())
+			return
+		}
+		if req.ActorTelegramID != 0 {
+			h.auditSvc.RecordCourtsReserved(r.Context(), id, req.GroupID, req.ActorTelegramID, req.ActorDisplay, req.Courts)
+		}
+		if len(cancelErrors) > 0 {
+			type failureItem struct {
+				Court  string `json:"court"`
+				Reason string `json:"reason"`
+			}
+			failures := make([]failureItem, len(cancelErrors))
+			for i, ce := range cancelErrors {
+				failures[i] = failureItem{Court: ce.CourtLabel, Reason: ce.Err.Error()}
+			}
+			for _, ce := range cancelErrors {
+				h.logger.Warn("updateCourts: partial cancellation failure",
+					"id", id, "court", ce.CourtLabel, "err", ce.Err)
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"canceled": canceledLabels,
+				"failed":   failures,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	if err := h.gameService.UpdateCourts(r.Context(), id, req.Courts); err != nil {
 		h.logger.Error("updateCourts", "err", err, "id", id)
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -142,6 +178,33 @@ func (h *Handler) updateCourts(w http.ResponseWriter, r *http.Request) {
 		h.auditSvc.RecordCourtsReserved(r.Context(), id, req.GroupID, req.ActorTelegramID, req.ActorDisplay, req.Courts)
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// listActiveCourtBookings handles GET /api/v1/games/{id}/active-court-bookings?courts=1,2
+func (h *Handler) listActiveCourtBookings(w http.ResponseWriter, r *http.Request) {
+	id, err := parseID(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid game id")
+		return
+	}
+	var courts []string
+	if raw := r.URL.Query().Get("courts"); raw != "" {
+		for _, p := range strings.Split(raw, ",") {
+			if t := strings.TrimSpace(p); t != "" {
+				courts = append(courts, t)
+			}
+		}
+	}
+	infos, err := h.gameService.ListActiveCourtBookings(r.Context(), id, courts)
+	if err != nil {
+		h.logger.Error("listActiveCourtBookings", "err", err, "id", id)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if infos == nil {
+		infos = []service.CourtBookingInfo{}
+	}
+	writeJSON(w, http.StatusOK, infos)
 }
 
 // getNextGame handles GET /api/v1/players/{telegramID}/next-game

--- a/cmd/management/api/server.go
+++ b/cmd/management/api/server.go
@@ -69,6 +69,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/v1/games/{id}/message-id", h.updateMessageID)
 	mux.HandleFunc("PATCH /api/v1/games/{id}/courts", h.updateCourts)
 	mux.HandleFunc("POST /api/v1/games/{id}/publish", h.publishGame)
+	mux.HandleFunc("GET /api/v1/games/{id}/active-court-bookings", h.listActiveCourtBookings)
 	// Participations
 	mux.HandleFunc("POST /api/v1/games/{id}/join", h.joinGame)
 	mux.HandleFunc("POST /api/v1/games/{id}/skip", h.skipGame)

--- a/cmd/management/main.go
+++ b/cmd/management/main.go
@@ -94,7 +94,6 @@ func main() {
 	auditSvc := service.NewAuditService(auditEventRepo, logger)
 	serverOwnerIDs := parseAdminIDs(cfg.ServiceAdminIDs)
 
-	gameService := service.NewGameService(gameRepo, venueRepo, participationRepo, guestRepo, groupRepo, auditSvc, tgAPI, loc, logger)
 	venueService := service.NewVenueService(venueRepo, courtBookingRepo)
 
 	var venueCredService *service.VenueCredentialService
@@ -122,6 +121,8 @@ func main() {
 	} else {
 		slog.Info("booking service disabled (SPORTS_BOOKING_SERVICE_URL not set); auto-cancellation and auto-booking disabled")
 	}
+
+	gameService := service.NewGameService(gameRepo, venueRepo, participationRepo, guestRepo, groupRepo, auditSvc, tgAPI, loc, logger, courtBookingRepo, bookingClient, venueCredService, autoBookingResultRepo)
 
 	gameNotifier := service.NewGameNotifier(tgAPI, gameRepo, participationRepo, guestRepo, groupRepo, loc, logger)
 	partService := service.NewParticipationService(playerRepo, participationRepo, guestRepo, gameNotifier)

--- a/cmd/management/service/booking_reminder_test.go
+++ b/cmd/management/service/booking_reminder_test.go
@@ -14,14 +14,16 @@ import (
 // ── mockGameRepo ──────────────────────────────────────────────────────────────
 
 type mockGameRepo struct {
-	createResult  *models.Game
-	createErr     error
-	getByIDResult *models.Game
-	getByIDErr    error
-	updateMsgErr  error
+	createResult    *models.Game
+	createErr       error
+	getByIDResult   *models.Game
+	getByIDErr      error
+	updateMsgErr    error
 	updateMsgCalled bool
-	existingGames []*models.Game
-	existingErr   error
+	existingGames   []*models.Game
+	existingErr     error
+	updateCourtsArg string
+	updateCourtsErr error
 }
 
 func (m *mockGameRepo) Create(_ context.Context, game *models.Game) (*models.Game, error) {
@@ -61,7 +63,10 @@ func (m *mockGameRepo) GetUpcomingGames(_ context.Context) ([]*models.Game, erro
 func (m *mockGameRepo) GetUpcomingGamesByChatIDs(_ context.Context, _ []int64) ([]*models.Game, error) {
 	return nil, nil
 }
-func (m *mockGameRepo) UpdateCourts(_ context.Context, _ int64, _ string, _ int) error { return nil }
+func (m *mockGameRepo) UpdateCourts(_ context.Context, _ int64, newCourts string, _ int) error {
+	m.updateCourtsArg = newCourts
+	return m.updateCourtsErr
+}
 func (m *mockGameRepo) GetNextGameForTelegramUser(_ context.Context, _ int64) (*models.Game, error) {
 	return nil, nil
 }
@@ -102,11 +107,12 @@ func (m *mockVenueRepo) SetLastAutoBookingAt(_ context.Context, _ int64) error {
 // ── mockAutoBookingResultRepo ─────────────────────────────────────────────────
 
 type mockAutoBookingResultRepo struct {
-	saveErr    error
-	saveCalls  int
-	results    []*models.AutoBookingResult
-	getByIDErr error
-	setGameErr error
+	saveErr      error
+	saveCalls    int
+	results      []*models.AutoBookingResult
+	getByIDErr   error
+	setGameErr   error
+	gameIDResult *models.AutoBookingResult // returned by GetByGameID
 }
 
 func (m *mockAutoBookingResultRepo) Save(_ context.Context, _ int64, _ time.Time, _, _ string, _ int) (int64, error) {
@@ -123,7 +129,7 @@ func (m *mockAutoBookingResultRepo) GetByVenueAndDateAndTime(_ context.Context, 
 }
 
 func (m *mockAutoBookingResultRepo) GetByGameID(_ context.Context, _ int64) (*models.AutoBookingResult, error) {
-	return nil, nil
+	return m.gameIDResult, nil
 }
 
 func (m *mockAutoBookingResultRepo) SetGameID(_ context.Context, _, _ int64) error {

--- a/cmd/management/service/game_service.go
+++ b/cmd/management/service/game_service.go
@@ -311,12 +311,26 @@ func (s *GameService) RemoveCourtsAndCancelBookings(ctx context.Context, gameID 
 		return nil, nil, s.gameRepo.UpdateCourts(ctx, gameID, newCourts, len(incoming))
 	}
 
-	entries, err := s.activeBookingsByLabels(ctx, game, removed)
+	// Unique labels for the repo query; cancel count per label caps how many we cancel.
+	cancelQuota := make(map[string]int, len(removed))
+	uniqueLabels := make([]string, 0, len(removed))
+	for _, l := range removed {
+		if cancelQuota[l] == 0 {
+			uniqueLabels = append(uniqueLabels, l)
+		}
+		cancelQuota[l]++
+	}
+
+	entries, err := s.activeBookingsByLabels(ctx, game, uniqueLabels)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get active bookings: %w", err)
 	}
 
 	for _, entry := range entries {
+		if cancelQuota[entry.CourtLabel] <= 0 {
+			continue
+		}
+		cancelQuota[entry.CourtLabel]--
 		login, password := "", ""
 		if entry.CredentialID != nil && s.credService != nil {
 			cred, credErr := s.credService.GetDecryptedByID(ctx, *entry.CredentialID)

--- a/cmd/management/service/game_service.go
+++ b/cmd/management/service/game_service.go
@@ -15,20 +15,43 @@ import (
 )
 
 var (
-	ErrGameNotFound       = errors.New("game not found")
+	ErrGameNotFound         = errors.New("game not found")
 	ErrGameAlreadyPublished = errors.New("game already published")
 )
 
+// CourtBookingInfo is a slim DTO returned by ListActiveCourtBookings.
+type CourtBookingInfo struct {
+	CourtLabel string `json:"court_label"`
+	GameTime   string `json:"game_time"`
+	MatchID    string `json:"match_id"`
+}
+
+// CourtCancelError carries the court label and the underlying error from a single
+// CancelMatch attempt, so the API layer can surface per-court failure details.
+type CourtCancelError struct {
+	CourtLabel string
+	Err        error
+}
+
+func (e *CourtCancelError) Error() string {
+	return fmt.Sprintf("court %s: %v", e.CourtLabel, e.Err)
+}
+
 type GameService struct {
-	gameRepo        GameRepository
-	venueRepo       VenueRepository
+	gameRepo          GameRepository
+	venueRepo         VenueRepository
 	participationRepo ParticipationRepository
-	guestRepo       GuestRepository
-	groupRepo       GroupRepository
-	auditSvc        *AuditService
-	api             TelegramAPI
-	defaultLoc      *time.Location
-	logger          *slog.Logger
+	guestRepo         GuestRepository
+	groupRepo         GroupRepository
+	auditSvc          *AuditService
+	api               TelegramAPI
+	defaultLoc        *time.Location
+	logger            *slog.Logger
+	// Optional booking deps — nil when booking infrastructure is not configured.
+	courtBookingRepo    CourtBookingRepository
+	bookingClient       BookingServiceClient
+	credService         *VenueCredentialService
+	autoBookingResultRepo AutoBookingResultRepository
 }
 
 func NewGameService(
@@ -41,17 +64,25 @@ func NewGameService(
 	api TelegramAPI,
 	defaultLoc *time.Location,
 	logger *slog.Logger,
+	courtBookingRepo CourtBookingRepository,
+	bookingClient BookingServiceClient,
+	credService *VenueCredentialService,
+	autoBookingResultRepo AutoBookingResultRepository,
 ) *GameService {
 	return &GameService{
-		gameRepo:          gameRepo,
-		venueRepo:         venueRepo,
-		participationRepo: participationRepo,
-		guestRepo:         guestRepo,
-		groupRepo:         groupRepo,
-		auditSvc:          auditSvc,
-		api:               api,
-		defaultLoc:        defaultLoc,
-		logger:            logger,
+		gameRepo:              gameRepo,
+		venueRepo:             venueRepo,
+		participationRepo:     participationRepo,
+		guestRepo:             guestRepo,
+		groupRepo:             groupRepo,
+		auditSvc:              auditSvc,
+		api:                   api,
+		defaultLoc:            defaultLoc,
+		logger:                logger,
+		courtBookingRepo:      courtBookingRepo,
+		bookingClient:         bookingClient,
+		credService:           credService,
+		autoBookingResultRepo: autoBookingResultRepo,
 	}
 }
 
@@ -182,4 +213,148 @@ func (s *GameService) PublishGame(ctx context.Context, gameID, actorTgID int64, 
 		return game, nil
 	}
 	return updated, nil
+}
+
+// activeBookingsByLabels returns active bookings for the given court labels on a game,
+// using time-slot scoping when the game is linked to an auto-booking result.
+// This prevents false matches when a venue hosts multiple sessions on the same date
+// that share the same court labels.
+func (s *GameService) activeBookingsByLabels(ctx context.Context, game *models.Game, labels []string) ([]*models.CourtBooking, error) {
+	var gameTime string
+	if s.autoBookingResultRepo != nil {
+		if abr, err := s.autoBookingResultRepo.GetByGameID(ctx, game.ID); err == nil && abr != nil {
+			gameTime = abr.GameTime
+		}
+	}
+
+	if gameTime != "" {
+		// Time-slot scoping: fetch only bookings for this game's time slot, then filter by label.
+		all, err := s.courtBookingRepo.GetByVenueAndDateAndTime(ctx, game.Venue.ID, game.GameDate, gameTime)
+		if err != nil {
+			return nil, err
+		}
+		labelSet := make(map[string]bool, len(labels))
+		for _, l := range labels {
+			labelSet[l] = true
+		}
+		var out []*models.CourtBooking
+		for _, b := range all {
+			if labelSet[b.CourtLabel] {
+				out = append(out, b)
+			}
+		}
+		return out, nil
+	}
+
+	// No game_time known (manually created game or legacy data) — fall back to date+label matching.
+	return s.courtBookingRepo.GetActiveByVenueDateAndLabels(ctx, game.Venue.ID, game.GameDate, labels)
+}
+
+// ListActiveCourtBookings returns slim booking info for active (non-canceled) bookings whose
+// court_label matches one of the provided labels. Returns empty slice when booking
+// infrastructure is absent or the game has no venue.
+func (s *GameService) ListActiveCourtBookings(ctx context.Context, gameID int64, courts []string) ([]CourtBookingInfo, error) {
+	if len(courts) == 0 || s.courtBookingRepo == nil {
+		return nil, nil
+	}
+	game, err := s.gameRepo.GetByID(ctx, gameID)
+	if err != nil {
+		return nil, fmt.Errorf("get game %d: %w", gameID, err)
+	}
+	if game.Venue == nil || game.Venue.ID == 0 {
+		return nil, nil
+	}
+	entries, err := s.activeBookingsByLabels(ctx, game, courts)
+	if err != nil {
+		return nil, fmt.Errorf("get active bookings: %w", err)
+	}
+	result := make([]CourtBookingInfo, 0, len(entries))
+	for _, e := range entries {
+		result = append(result, CourtBookingInfo{
+			CourtLabel: e.CourtLabel,
+			GameTime:   e.GameTime,
+			MatchID:    e.MatchID,
+		})
+	}
+	return result, nil
+}
+
+// RemoveCourtsAndCancelBookings cancels active Eversports bookings for courts that are
+// being removed (present in game.Courts but not in newCourts), then persists newCourts.
+// The DB update always runs regardless of cancellation failures — the admin's chosen
+// court list is persisted and partial failures are reported back via CourtCancelError.
+func (s *GameService) RemoveCourtsAndCancelBookings(ctx context.Context, gameID int64, newCourts string) (canceledLabels []string, cancelErrors []CourtCancelError, err error) {
+	game, err := s.gameRepo.GetByID(ctx, gameID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get game %d: %w", gameID, err)
+	}
+
+	current := splitCourts(game.Courts)
+	incoming := splitCourts(newCourts)
+
+	// Multiset diff: labels in current but not in incoming.
+	incomingCount := make(map[string]int, len(incoming))
+	for _, c := range incoming {
+		incomingCount[c]++
+	}
+	var removed []string
+	for _, c := range current {
+		if incomingCount[c] > 0 {
+			incomingCount[c]--
+		} else {
+			removed = append(removed, c)
+		}
+	}
+
+	if len(removed) == 0 || game.Venue == nil || game.Venue.ID == 0 ||
+		s.courtBookingRepo == nil || s.bookingClient == nil {
+		return nil, nil, s.gameRepo.UpdateCourts(ctx, gameID, newCourts, len(incoming))
+	}
+
+	entries, err := s.activeBookingsByLabels(ctx, game, removed)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get active bookings: %w", err)
+	}
+
+	for _, entry := range entries {
+		login, password := "", ""
+		if entry.CredentialID != nil && s.credService != nil {
+			cred, credErr := s.credService.GetDecryptedByID(ctx, *entry.CredentialID)
+			if credErr != nil {
+				s.logger.Error("RemoveCourtsAndCancelBookings: get credential",
+					"game_id", gameID, "cred_id", *entry.CredentialID, "err", credErr)
+				cancelErrors = append(cancelErrors, CourtCancelError{CourtLabel: entry.CourtLabel, Err: credErr})
+				continue
+			}
+			if cred != nil {
+				login, password = cred.Login, cred.Password
+			}
+		}
+		if login == "" {
+			noCredErr := fmt.Errorf("no credentials available")
+			s.logger.Warn("RemoveCourtsAndCancelBookings: no credentials for court",
+				"game_id", gameID, "court_label", entry.CourtLabel)
+			cancelErrors = append(cancelErrors, CourtCancelError{CourtLabel: entry.CourtLabel, Err: noCredErr})
+			continue
+		}
+		if cancelErr := s.bookingClient.CancelMatch(ctx, entry.MatchID, login, password); cancelErr != nil {
+			s.logger.Error("RemoveCourtsAndCancelBookings: cancel match",
+				"game_id", gameID, "court_label", entry.CourtLabel, "match_id", entry.MatchID, "err", cancelErr)
+			cancelErrors = append(cancelErrors, CourtCancelError{CourtLabel: entry.CourtLabel, Err: cancelErr})
+			continue
+		}
+		if markErr := s.courtBookingRepo.MarkCanceled(ctx, entry.MatchID); markErr != nil {
+			s.logger.Error("RemoveCourtsAndCancelBookings: mark canceled",
+				"game_id", gameID, "match_id", entry.MatchID, "err", markErr)
+		}
+		if s.auditSvc != nil {
+			s.auditSvc.RecordCourtCanceled(ctx, game.Venue.ID, game.ChatID, game.Venue.Name, entry.CourtLabel, game.GameDate)
+		}
+		canceledLabels = append(canceledLabels, entry.CourtLabel)
+	}
+
+	if updateErr := s.gameRepo.UpdateCourts(ctx, gameID, newCourts, len(incoming)); updateErr != nil {
+		return canceledLabels, cancelErrors, fmt.Errorf("update courts: %w", updateErr)
+	}
+	return canceledLabels, cancelErrors, nil
 }

--- a/cmd/management/service/game_service_courts_test.go
+++ b/cmd/management/service/game_service_courts_test.go
@@ -1,0 +1,382 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hutoroff/squash-bot/internal/models"
+)
+
+// ── mockCourtBookingRepo ──────────────────────────────────────────────────────
+
+type mockCourtBookingRepo struct {
+	// labelEntries are returned by GetActiveByVenueDateAndLabels.
+	labelEntries []*models.CourtBooking
+	// timeEntries are returned by GetByVenueAndDateAndTime.
+	timeEntries    []*models.CourtBooking
+	getErr         error
+	markedCanceled []string
+}
+
+func (r *mockCourtBookingRepo) Save(_ context.Context, _ *models.CourtBooking) error { return nil }
+func (r *mockCourtBookingRepo) GetByVenueAndDate(_ context.Context, _ int64, _ time.Time) ([]*models.CourtBooking, error) {
+	return nil, nil
+}
+func (r *mockCourtBookingRepo) GetByVenueAndDateAndTime(_ context.Context, _ int64, _ time.Time, _ string) ([]*models.CourtBooking, error) {
+	return r.timeEntries, r.getErr
+}
+func (r *mockCourtBookingRepo) MarkCanceled(_ context.Context, matchID string) error {
+	r.markedCanceled = append(r.markedCanceled, matchID)
+	return nil
+}
+func (r *mockCourtBookingRepo) MarkCanceledByVenueAndDate(_ context.Context, _ int64, _ time.Time) error {
+	return nil
+}
+func (r *mockCourtBookingRepo) HasActiveByCredentialID(_ context.Context, _ int64) (bool, error) {
+	return false, nil
+}
+func (r *mockCourtBookingRepo) HasActiveByVenueID(_ context.Context, _ int64) (bool, error) {
+	return false, nil
+}
+func (r *mockCourtBookingRepo) GetActiveByVenueDateAndLabels(_ context.Context, _ int64, _ time.Time, _ []string) ([]*models.CourtBooking, error) {
+	return r.labelEntries, r.getErr
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func gameWithVenueAndCourts(courts string, venueID int64) *models.Game {
+	return &models.Game{
+		ID:       10,
+		Courts:   courts,
+		GameDate: time.Date(2026, 5, 10, 10, 0, 0, 0, time.UTC),
+		Venue:    &models.Venue{ID: venueID},
+	}
+}
+
+func newCourtsGameSvc(
+	gameRepo GameRepository,
+	cbRepo CourtBookingRepository,
+	bc BookingServiceClient,
+	abrRepo AutoBookingResultRepository,
+	credSvc *VenueCredentialService,
+) *GameService {
+	return &GameService{
+		gameRepo:              gameRepo,
+		participationRepo:     &stubParticipationRepo{},
+		guestRepo:             &stubGuestParticipationRepo{},
+		groupRepo:             &stubGroupRepoForDayAfter{},
+		defaultLoc:            time.UTC,
+		logger:                noopLogger(),
+		courtBookingRepo:      cbRepo,
+		bookingClient:         bc,
+		autoBookingResultRepo: abrRepo,
+		credService:           credSvc,
+	}
+}
+
+// ── RemoveCourtsAndCancelBookings ─────────────────────────────────────────────
+
+func TestRemoveCourtsAndCancelBookings_NoCourtsRemoved(t *testing.T) {
+	game := gameWithVenueAndCourts("Court 1,Court 2", 1)
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	bc := &mockBookingClient{}
+	svc := newCourtsGameSvc(gameRepo, &mockCourtBookingRepo{}, bc, nil, nil)
+
+	_, cancelErrs, err := svc.RemoveCourtsAndCancelBookings(context.Background(), game.ID, "Court 1,Court 2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cancelErrs) > 0 {
+		t.Errorf("expected no cancel errors, got %v", cancelErrs)
+	}
+	if len(bc.cancelCalls) > 0 {
+		t.Errorf("expected no CancelMatch, got %v", bc.cancelCalls)
+	}
+}
+
+func TestRemoveCourtsAndCancelBookings_NoVenue(t *testing.T) {
+	game := &models.Game{ID: 10, Courts: "Court 1,Court 2", GameDate: time.Now()}
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	bc := &mockBookingClient{}
+	svc := newCourtsGameSvc(gameRepo, &mockCourtBookingRepo{}, bc, nil, nil)
+
+	_, _, err := svc.RemoveCourtsAndCancelBookings(context.Background(), game.ID, "Court 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(bc.cancelCalls) > 0 {
+		t.Errorf("expected no CancelMatch when no venue, got %v", bc.cancelCalls)
+	}
+}
+
+func TestRemoveCourtsAndCancelBookings_NoBookingInfra(t *testing.T) {
+	game := gameWithVenueAndCourts("Court 1,Court 2", 1)
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	svc := newCourtsGameSvc(gameRepo, nil, nil, nil, nil)
+
+	_, _, err := svc.RemoveCourtsAndCancelBookings(context.Background(), game.ID, "Court 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRemoveCourtsAndCancelBookings_NoActiveBookings(t *testing.T) {
+	game := gameWithVenueAndCourts("Court 1,Court 2", 1)
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	cbRepo := &mockCourtBookingRepo{} // returns nil entries
+	bc := &mockBookingClient{}
+	svc := newCourtsGameSvc(gameRepo, cbRepo, bc, nil, nil)
+
+	_, cancelErrs, err := svc.RemoveCourtsAndCancelBookings(context.Background(), game.ID, "Court 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cancelErrs) > 0 {
+		t.Errorf("expected no cancel errors, got %v", cancelErrs)
+	}
+	if len(bc.cancelCalls) > 0 {
+		t.Errorf("expected no CancelMatch when no bookings, got %v", bc.cancelCalls)
+	}
+}
+
+func TestRemoveCourtsAndCancelBookings_HappyPath(t *testing.T) {
+	credID := int64(1)
+	game := gameWithVenueAndCourts("Court 1,Court 2", 1)
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	cbRepo := &mockCourtBookingRepo{
+		labelEntries: []*models.CourtBooking{
+			{CourtLabel: "Court 2", MatchID: "match-uuid-2", CredentialID: &credID},
+		},
+	}
+	bc := &mockBookingClient{}
+	credSvc := makeAlgorithmCredService()
+	svc := newCourtsGameSvc(gameRepo, cbRepo, bc, nil, credSvc)
+
+	canceled, cancelErrs, err := svc.RemoveCourtsAndCancelBookings(context.Background(), game.ID, "Court 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cancelErrs) > 0 {
+		t.Errorf("expected no cancel errors, got %v", cancelErrs)
+	}
+	if len(canceled) != 1 || canceled[0] != "Court 2" {
+		t.Errorf("expected [Court 2] canceled, got %v", canceled)
+	}
+	if len(bc.cancelCalls) != 1 || bc.cancelCalls[0] != "match-uuid-2" {
+		t.Errorf("expected CancelMatch(match-uuid-2), got %v", bc.cancelCalls)
+	}
+	if len(cbRepo.markedCanceled) != 1 || cbRepo.markedCanceled[0] != "match-uuid-2" {
+		t.Errorf("expected MarkCanceled(match-uuid-2), got %v", cbRepo.markedCanceled)
+	}
+}
+
+func TestRemoveCourtsAndCancelBookings_CancelFails_DBStillUpdated(t *testing.T) {
+	credID := int64(1)
+	game := gameWithVenueAndCourts("Court 1,Court 2", 1)
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	cbRepo := &mockCourtBookingRepo{
+		labelEntries: []*models.CourtBooking{
+			{CourtLabel: "Court 2", MatchID: "match-uuid-2", CredentialID: &credID},
+		},
+	}
+	bc := &mockBookingClient{cancelErr: errors.New("eversports 503")}
+	credSvc := makeAlgorithmCredService()
+	svc := newCourtsGameSvc(gameRepo, cbRepo, bc, nil, credSvc)
+
+	canceled, cancelErrs, err := svc.RemoveCourtsAndCancelBookings(context.Background(), game.ID, "Court 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(canceled) > 0 {
+		t.Errorf("expected no canceled labels on failure, got %v", canceled)
+	}
+	if len(cancelErrs) != 1 || cancelErrs[0].CourtLabel != "Court 2" {
+		t.Errorf("expected 1 cancel error for Court 2, got %v", cancelErrs)
+	}
+	// UpdateCourts must be called even when cancellation fails.
+	if gameRepo.updateCourtsArg == "" {
+		t.Error("expected UpdateCourts to be called even on cancel failure")
+	}
+}
+
+func TestRemoveCourtsAndCancelBookings_NoCredentials(t *testing.T) {
+	// Entry has nil CredentialID — no credentials path.
+	game := gameWithVenueAndCourts("Court 1,Court 2", 1)
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	cbRepo := &mockCourtBookingRepo{
+		labelEntries: []*models.CourtBooking{
+			{CourtLabel: "Court 2", MatchID: "match-uuid-2", CredentialID: nil},
+		},
+	}
+	bc := &mockBookingClient{}
+	svc := newCourtsGameSvc(gameRepo, cbRepo, bc, nil, nil)
+
+	_, cancelErrs, err := svc.RemoveCourtsAndCancelBookings(context.Background(), game.ID, "Court 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cancelErrs) != 1 || cancelErrs[0].CourtLabel != "Court 2" {
+		t.Errorf("expected 1 cancel error for Court 2, got %v", cancelErrs)
+	}
+	if len(bc.cancelCalls) > 0 {
+		t.Errorf("expected no CancelMatch when no credentials, got %v", bc.cancelCalls)
+	}
+}
+
+func TestRemoveCourtsAndCancelBookings_MultisetDiff(t *testing.T) {
+	// Game has "Court 1,Court 1,Court 2". New courts are "Court 1,Court 2".
+	// Multiset diff: one "Court 1" is removed. The repo returns TWO active bookings for
+	// "Court 1" (one per original slot). Only ONE CancelMatch should happen because the
+	// quota for "Court 1" in the diff is 1 — the second booking must be left intact.
+	credID := int64(1)
+	game := &models.Game{
+		ID:       10,
+		Courts:   "Court 1,Court 1,Court 2",
+		GameDate: time.Date(2026, 5, 10, 10, 0, 0, 0, time.UTC),
+		Venue:    &models.Venue{ID: 1},
+	}
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	cbRepo := &mockCourtBookingRepo{
+		labelEntries: []*models.CourtBooking{
+			{CourtLabel: "Court 1", MatchID: "match-1a", CredentialID: &credID},
+			{CourtLabel: "Court 1", MatchID: "match-1b", CredentialID: &credID},
+		},
+	}
+	bc := &mockBookingClient{}
+	credSvc := makeAlgorithmCredService()
+	svc := newCourtsGameSvc(gameRepo, cbRepo, bc, nil, credSvc)
+
+	canceled, cancelErrs, err := svc.RemoveCourtsAndCancelBookings(context.Background(), game.ID, "Court 1,Court 2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cancelErrs) > 0 {
+		t.Errorf("unexpected cancel errors: %v", cancelErrs)
+	}
+	if len(canceled) != 1 || canceled[0] != "Court 1" {
+		t.Errorf("expected exactly [Court 1] canceled, got %v", canceled)
+	}
+	if len(bc.cancelCalls) != 1 {
+		t.Errorf("expected exactly 1 CancelMatch (quota=1), got %v", bc.cancelCalls)
+	}
+}
+
+// ── activeBookingsByLabels routing ────────────────────────────────────────────
+
+func TestActiveBookingsByLabels_NoResultRepo_UsesLabelQuery(t *testing.T) {
+	game := gameWithVenueAndCourts("Court 1", 1)
+	expected := []*models.CourtBooking{{CourtLabel: "Court 1", MatchID: "m1"}}
+	cbRepo := &mockCourtBookingRepo{labelEntries: expected}
+	svc := newCourtsGameSvc(&mockGameRepo{}, cbRepo, nil, nil, nil)
+
+	got, err := svc.activeBookingsByLabels(context.Background(), game, []string{"Court 1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].MatchID != "m1" {
+		t.Errorf("expected label-based result, got %v", got)
+	}
+}
+
+func TestActiveBookingsByLabels_WithGameTime_FiltersLabel(t *testing.T) {
+	// autoBookingResultRepo returns a result with game_time → uses GetByVenueAndDateAndTime
+	// and filters to only the requested label.
+	game := gameWithVenueAndCourts("Court 1,Court 2", 1)
+	abrRepo := &mockAutoBookingResultRepo{
+		gameIDResult: &models.AutoBookingResult{GameTime: "10:00"},
+	}
+	cbRepo := &mockCourtBookingRepo{
+		timeEntries: []*models.CourtBooking{
+			{CourtLabel: "Court 1", MatchID: "m1"},
+			{CourtLabel: "Court 2", MatchID: "m2"},
+		},
+	}
+	svc := newCourtsGameSvc(&mockGameRepo{}, cbRepo, nil, abrRepo, nil)
+
+	// Request only Court 2 — must exclude Court 1 despite it being in timeEntries.
+	got, err := svc.activeBookingsByLabels(context.Background(), game, []string{"Court 2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].MatchID != "m2" {
+		t.Errorf("expected only Court 2 (m2), got %v", got)
+	}
+}
+
+func TestActiveBookingsByLabels_NilAutoBookingResult_FallsBack(t *testing.T) {
+	// autoBookingResultRepo.GetByGameID returns nil → fall back to label query.
+	game := gameWithVenueAndCourts("Court 1", 1)
+	expected := []*models.CourtBooking{{CourtLabel: "Court 1", MatchID: "m-fallback"}}
+	abrRepo := &mockAutoBookingResultRepo{gameIDResult: nil}
+	cbRepo := &mockCourtBookingRepo{labelEntries: expected}
+	svc := newCourtsGameSvc(&mockGameRepo{}, cbRepo, nil, abrRepo, nil)
+
+	got, err := svc.activeBookingsByLabels(context.Background(), game, []string{"Court 1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].MatchID != "m-fallback" {
+		t.Errorf("expected fallback result, got %v", got)
+	}
+}
+
+// ── ListActiveCourtBookings ───────────────────────────────────────────────────
+
+func TestListActiveCourtBookings_EmptyCourts(t *testing.T) {
+	svc := newCourtsGameSvc(&mockGameRepo{}, &mockCourtBookingRepo{}, nil, nil, nil)
+	result, err := svc.ListActiveCourtBookings(context.Background(), 1, nil)
+	if err != nil || result != nil {
+		t.Errorf("expected (nil, nil) for empty courts, got (%v, %v)", result, err)
+	}
+}
+
+func TestListActiveCourtBookings_NilRepo(t *testing.T) {
+	svc := newCourtsGameSvc(&mockGameRepo{}, nil, nil, nil, nil)
+	result, err := svc.ListActiveCourtBookings(context.Background(), 1, []string{"Court 1"})
+	if err != nil || result != nil {
+		t.Errorf("expected (nil, nil) when no repo, got (%v, %v)", result, err)
+	}
+}
+
+func TestListActiveCourtBookings_GameNotFound(t *testing.T) {
+	gameRepo := &mockGameRepo{getByIDErr: errors.New("not found")}
+	svc := newCourtsGameSvc(gameRepo, &mockCourtBookingRepo{}, nil, nil, nil)
+	_, err := svc.ListActiveCourtBookings(context.Background(), 99, []string{"Court 1"})
+	if err == nil {
+		t.Error("expected error when game not found")
+	}
+}
+
+func TestListActiveCourtBookings_NoVenue(t *testing.T) {
+	gameRepo := &mockGameRepo{getByIDResult: &models.Game{ID: 1}}
+	svc := newCourtsGameSvc(gameRepo, &mockCourtBookingRepo{}, nil, nil, nil)
+	result, err := svc.ListActiveCourtBookings(context.Background(), 1, []string{"Court 1"})
+	if err != nil || result != nil {
+		t.Errorf("expected (nil, nil) when no venue, got (%v, %v)", result, err)
+	}
+}
+
+func TestListActiveCourtBookings_HappyPath(t *testing.T) {
+	game := gameWithVenueAndCourts("Court 1,Court 2", 1)
+	gameRepo := &mockGameRepo{getByIDResult: game}
+	cbRepo := &mockCourtBookingRepo{
+		labelEntries: []*models.CourtBooking{
+			{CourtLabel: "Court 1", GameTime: "10:00", MatchID: "m1"},
+		},
+	}
+	svc := newCourtsGameSvc(gameRepo, cbRepo, nil, nil, nil)
+
+	result, err := svc.ListActiveCourtBookings(context.Background(), game.ID, []string{"Court 1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+	r := result[0]
+	if r.CourtLabel != "Court 1" || r.MatchID != "m1" || r.GameTime != "10:00" {
+		t.Errorf("unexpected result fields: %+v", r)
+	}
+}

--- a/cmd/management/service/game_service_test.go
+++ b/cmd/management/service/game_service_test.go
@@ -17,7 +17,7 @@ func TestGameService_CreateGame(t *testing.T) {
 	if err := testutil.Truncate(ctx, testPool); err != nil {
 		t.Fatal(err)
 	}
-	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 
 	gameDate := time.Now().Add(48 * time.Hour)
 	game, err := svc.CreateGame(ctx, -1001, gameDate, "2,3,4", nil)
@@ -45,7 +45,7 @@ func TestGameService_CreateGame_SingleCourt(t *testing.T) {
 	if err := testutil.Truncate(ctx, testPool); err != nil {
 		t.Fatal(err)
 	}
-	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 
 	game, err := svc.CreateGame(ctx, -1, time.Now().Add(24*time.Hour), "5", nil)
 	if err != nil {
@@ -61,7 +61,7 @@ func TestGameService_UpdateMessageID(t *testing.T) {
 	if err := testutil.Truncate(ctx, testPool); err != nil {
 		t.Fatal(err)
 	}
-	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 
 	game, _ := svc.CreateGame(ctx, -1, time.Now().Add(24*time.Hour), "1", nil)
 	if err := svc.UpdateMessageID(ctx, game.ID, 12345); err != nil {
@@ -82,7 +82,7 @@ func TestGameService_GetByID_NotFound(t *testing.T) {
 	if err := testutil.Truncate(ctx, testPool); err != nil {
 		t.Fatal(err)
 	}
-	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 
 	_, err := svc.GetByID(ctx, 9999999)
 	if err == nil {
@@ -96,7 +96,7 @@ func TestGameService_GetNextGameForTelegramUser_Registered(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gameSvc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	gameSvc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 	partSvc := service.NewParticipationService(
 		storage.NewPlayerRepo(testPool),
 		storage.NewParticipationRepo(testPool),
@@ -124,7 +124,7 @@ func TestGameService_GetNextGameForTelegramUser_NoGame(t *testing.T) {
 	if err := testutil.Truncate(ctx, testPool); err != nil {
 		t.Fatal(err)
 	}
-	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 
 	got, err := svc.GetNextGameForTelegramUser(ctx, 99999)
 	if err != nil {
@@ -140,7 +140,7 @@ func TestGameService_UpdateCourts(t *testing.T) {
 	if err := testutil.Truncate(ctx, testPool); err != nil {
 		t.Fatal(err)
 	}
-	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	svc := service.NewGameService(storage.NewGameRepo(testPool), storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 
 	game, _ := svc.CreateGame(ctx, -1, time.Now().Add(24*time.Hour), "1,2", nil)
 

--- a/cmd/management/service/interfaces.go
+++ b/cmd/management/service/interfaces.go
@@ -115,6 +115,9 @@ type CourtBookingRepository interface {
 	// MarkCanceledByVenueAndDate soft-deletes all active bookings for the venue on the given date.
 	// Called by DayAfterCleanupJob to close out kept bookings after a game completes.
 	MarkCanceledByVenueAndDate(ctx context.Context, venueID int64, gameDate time.Time) error
+	// GetActiveByVenueDateAndLabels returns active bookings for the venue+date whose court_label
+	// matches one of the provided labels. Used by the manual court-removal flow.
+	GetActiveByVenueDateAndLabels(ctx context.Context, venueID int64, gameDate time.Time, labels []string) ([]*models.CourtBooking, error)
 }
 
 // VenueCredentialRepository is the data access interface for venue booking credentials.

--- a/cmd/management/service/participation_service_test.go
+++ b/cmd/management/service/participation_service_test.go
@@ -28,7 +28,7 @@ func setupParticipationTest(t *testing.T, ctx context.Context) (
 	partRepo := storage.NewParticipationRepo(testPool)
 	guestRepo := storage.NewGuestRepo(testPool)
 
-	gameSvc := service.NewGameService(gameRepo, storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	gameSvc := service.NewGameService(gameRepo, storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 	partSvc := service.NewParticipationService(playerRepo, partRepo, guestRepo, nil)
 
 	game, err := gameSvc.CreateGame(ctx, -1001, time.Now().Add(48*time.Hour), "1,2", nil)
@@ -396,7 +396,7 @@ func TestParticipationService_AddGuest_AtCapacity(t *testing.T) {
 	partRepo := storage.NewParticipationRepo(testPool)
 	guestRepo := storage.NewGuestRepo(testPool)
 	partSvc := service.NewParticipationService(playerRepo, partRepo, guestRepo, nil)
-	gameSvc := service.NewGameService(gameRepo, storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil)
+	gameSvc := service.NewGameService(gameRepo, storage.NewVenueRepo(testPool), nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil)
 
 	// 1 court → capacity 2.
 	game, err := gameSvc.CreateGame(ctx, -1001, time.Now().Add(48*time.Hour), "1", nil)
@@ -577,8 +577,8 @@ func TestParticipationService_KickGuestByID_WrongGame(t *testing.T) {
 	svc := service.NewParticipationService(playerRepo, partRepo, guestRepo, nil)
 
 	venueRepo := storage.NewVenueRepo(testPool)
-	gA, _ := service.NewGameService(gameRepo, venueRepo, nil, nil, nil, nil, nil, time.UTC, nil).CreateGame(ctx, -1001, time.Now().Add(48*time.Hour), "1,2", nil)
-	gB, _ := service.NewGameService(gameRepo, venueRepo, nil, nil, nil, nil, nil, time.UTC, nil).CreateGame(ctx, -1001, time.Now().Add(96*time.Hour), "3,4", nil)
+	gA, _ := service.NewGameService(gameRepo, venueRepo, nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil).CreateGame(ctx, -1001, time.Now().Add(48*time.Hour), "1,2", nil)
+	gB, _ := service.NewGameService(gameRepo, venueRepo, nil, nil, nil, nil, nil, time.UTC, nil, nil, nil, nil, nil).CreateGame(ctx, -1001, time.Now().Add(96*time.Hour), "3,4", nil)
 
 	_, _, _, _ = svc.AddGuest(ctx, gA.ID, 40011, "eve", "", "") // guest belongs to game A
 	guestsA, _ := svc.GetGuests(ctx, gA.ID)

--- a/cmd/management/service/scheduler_cancellation_test.go
+++ b/cmd/management/service/scheduler_cancellation_test.go
@@ -561,6 +561,10 @@ func (r *stubCourtBookingRepo) MarkCanceledByVenueAndDate(_ context.Context, _ i
 	return nil
 }
 
+func (r *stubCourtBookingRepo) GetActiveByVenueDateAndLabels(_ context.Context, _ int64, _ time.Time, _ []string) ([]*models.CourtBooking, error) {
+	return nil, nil
+}
+
 // courtBookingEntry is a convenience constructor for test CourtBooking entries.
 func courtBookingEntry(label, matchID string, credID *int64) *models.CourtBooking {
 	return &models.CourtBooking{CourtLabel: label, MatchID: matchID, CredentialID: credID}
@@ -902,6 +906,10 @@ func (r *routingCourtBookingRepo) MarkCanceled(_ context.Context, matchID string
 
 func (r *routingCourtBookingRepo) MarkCanceledByVenueAndDate(_ context.Context, _ int64, _ time.Time) error {
 	return nil
+}
+
+func (r *routingCourtBookingRepo) GetActiveByVenueDateAndLabels(_ context.Context, _ int64, _ time.Time, _ []string) ([]*models.CourtBooking, error) {
+	return nil, nil
 }
 
 func (r *routingCourtBookingRepo) HasActiveByCredentialID(_ context.Context, _ int64) (bool, error) {

--- a/cmd/management/storage/court_booking_repo.go
+++ b/cmd/management/storage/court_booking_repo.go
@@ -114,6 +114,34 @@ func (r *CourtBookingRepo) HasActiveByVenueID(ctx context.Context, venueID int64
 	return exists, err
 }
 
+// GetActiveByVenueDateAndLabels returns active bookings for the venue+date whose court_label
+// matches one of the provided labels. Used by the manual court-removal flow.
+func (r *CourtBookingRepo) GetActiveByVenueDateAndLabels(ctx context.Context, venueID int64, gameDate time.Time, labels []string) ([]*models.CourtBooking, error) {
+	const q = `
+		SELECT id, venue_id, game_date, game_time, court_uuid, court_label, match_id, booking_uuid,
+		       credential_id, canceled_at, created_at
+		FROM court_bookings
+		WHERE venue_id = $1 AND game_date = $2 AND court_label = ANY($3) AND canceled_at IS NULL
+		ORDER BY id ASC`
+	rows, err := r.pool.Query(ctx, q, venueID, gameDate, labels)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []*models.CourtBooking
+	for rows.Next() {
+		var b models.CourtBooking
+		if err := rows.Scan(
+			&b.ID, &b.VenueID, &b.GameDate, &b.GameTime, &b.CourtUUID, &b.CourtLabel,
+			&b.MatchID, &b.BookingUUID, &b.CredentialID, &b.CanceledAt, &b.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		result = append(result, &b)
+	}
+	return result, rows.Err()
+}
+
 // MarkCanceledByVenueAndDate soft-deletes all active bookings for the venue on the given date.
 func (r *CourtBookingRepo) MarkCanceledByVenueAndDate(ctx context.Context, venueID int64, gameDate time.Time) error {
 	const q = `UPDATE court_bookings SET canceled_at = NOW() WHERE venue_id = $1 AND game_date = $2 AND canceled_at IS NULL`

--- a/cmd/telegram/client/client.go
+++ b/cmd/telegram/client/client.go
@@ -469,6 +469,66 @@ func (c *Client) TriggerScheduledEvent(ctx context.Context, event string) error 
 	return c.do(ctx, http.MethodPost, "/api/v1/scheduler/trigger/"+event, nil, nil)
 }
 
+// CourtBookingInfo is a slim DTO for an active court booking returned by ListActiveCourtBookings.
+type CourtBookingInfo struct {
+	CourtLabel string `json:"court_label"`
+	GameTime   string `json:"game_time"`
+	MatchID    string `json:"match_id"`
+}
+
+// CancelFailure describes a court whose booking cancellation failed.
+type CancelFailure struct {
+	Court  string `json:"court"`
+	Reason string `json:"reason"`
+}
+
+// ListActiveCourtBookings returns active Eversports bookings for the given court labels on a game.
+func (c *Client) ListActiveCourtBookings(ctx context.Context, gameID int64, courts []string) ([]CourtBookingInfo, error) {
+	path := fmt.Sprintf("/api/v1/games/%d/active-court-bookings?courts=%s",
+		gameID, url.QueryEscape(strings.Join(courts, ",")))
+	var infos []CourtBookingInfo
+	if err := c.do(ctx, http.MethodGet, path, nil, &infos); err != nil {
+		return nil, err
+	}
+	return infos, nil
+}
+
+// UpdateCourtsAndCancelBookings cancels active bookings for removed courts then persists the new courts list.
+// On partial failure, failed contains per-court errors and courts are still updated.
+func (c *Client) UpdateCourtsAndCancelBookings(ctx context.Context, gameID, groupID int64, newCourts, actorDisplay string, actorTgID int64) (canceledLabels []string, failed []CancelFailure, err error) {
+	body := map[string]any{
+		"courts":            newCourts,
+		"group_id":          groupID,
+		"actor_telegram_id": actorTgID,
+		"actor_display":     actorDisplay,
+		"cancel_bookings":   true,
+	}
+	req, reqErr := c.newRequest(ctx, http.MethodPatch, "/api/v1/games/"+strconv.FormatInt(gameID, 10)+"/courts", body)
+	if reqErr != nil {
+		return nil, nil, reqErr
+	}
+	resp, doErr := c.httpClient.Do(req)
+	if doErr != nil {
+		return nil, nil, fmt.Errorf("PATCH /courts: %w", doErr)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, nil, parseErrorBody(resp)
+	}
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, nil, nil
+	}
+	var partial struct {
+		Canceled []string        `json:"canceled"`
+		Failed   []CancelFailure `json:"failed"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&partial); err != nil {
+		return nil, nil, fmt.Errorf("decode partial response: %w", err)
+	}
+	return partial.Canceled, partial.Failed, nil
+}
+
 // ErrAlreadyPublished is returned by PublishGame when the management service responds with HTTP 409.
 var ErrAlreadyPublished = errors.New("already published")
 

--- a/cmd/telegram/client/interface.go
+++ b/cmd/telegram/client/interface.go
@@ -56,4 +56,11 @@ type ManagementClient interface {
 
 	// PublishGame sends the game announcement and pins it. Returns ErrAlreadyPublished (HTTP 409) if already done.
 	PublishGame(ctx context.Context, gameID, actorTgID int64, actorDisplay string) (*models.Game, error)
+
+	// ListActiveCourtBookings returns active Eversports bookings for the given courts of a game.
+	ListActiveCourtBookings(ctx context.Context, gameID int64, courts []string) ([]CourtBookingInfo, error)
+
+	// UpdateCourtsAndCancelBookings cancels active bookings for removed courts then updates courts.
+	// On partial cancellation failure, failed is non-empty and the courts update still happened.
+	UpdateCourtsAndCancelBookings(ctx context.Context, gameID, groupID int64, newCourts, actorDisplay string, actorTgID int64) (canceledLabels []string, failed []CancelFailure, err error)
 }

--- a/cmd/telegram/telegram/bot.go
+++ b/cmd/telegram/telegram/bot.go
@@ -152,6 +152,17 @@ type manageCourtsToggleState struct {
 	selectedCourts map[string]bool
 }
 
+// manageCourtsCancelPromptState holds context for the confirmation step shown when
+// removing courts that have active Eversports bookings.
+// Keyed by private chat ID in pendingManageCourtsCancelPrompt.
+type manageCourtsCancelPromptState struct {
+	gameID       int64
+	groupID      int64
+	newCourts    string   // the courts string the admin wants to apply
+	bookedLabels []string // court labels that have active bookings
+	venueCourts  []string // all venue courts (for the "back" re-render)
+}
+
 // gameEditWorker serializes and coalesces Telegram message edits for a single game.
 // Multiple concurrent triggers (e.g. rapid join/skip button clicks) collapse into
 // at most two sequential Telegram API calls, preventing 429 rate-limit errors.
@@ -225,7 +236,8 @@ type Bot struct {
 	logger                        *slog.Logger
 	pendingGames                  sync.Map      // map[pendingGameKey]*pendingGame
 	pendingCourtsEdit             sync.Map      // map[chatID int64]gameID int64
-	pendingManageCourtsToggle     sync.Map      // map[chatID int64]*manageCourtsToggleState
+	pendingManageCourtsToggle        sync.Map      // map[chatID int64]*manageCourtsToggleState
+	pendingManageCourtsCancelPrompt  sync.Map      // map[chatID int64]*manageCourtsCancelPromptState
 	pendingNewGameWizard          sync.Map      // map[chatID int64]*newGameWizard
 	pendingVenueWizard            sync.Map      // map[chatID int64]*venueWizard
 	pendingVenueEdit              sync.Map      // map[chatID int64]*venueEditState

--- a/cmd/telegram/telegram/callback_router.go
+++ b/cmd/telegram/telegram/callback_router.go
@@ -100,8 +100,10 @@ func (b *Bot) buildCallbackRouter() map[string]callbackHandler {
 			}
 			b.handleManageKickGuest(ctx, cb, gid, tid)
 		},
-		"manage_court_toggle":  b.handleManageCourtsToggle,
-		"manage_court_confirm": int64H(b.handleManageCourtsConfirm),
+		"manage_court_toggle":          b.handleManageCourtsToggle,
+		"manage_court_confirm":         int64H(b.handleManageCourtsConfirm),
+		"manage_courts_cancel_confirm": int64H(b.handleManageCourtsCancelConfirm),
+		"manage_courts_cancel_abort":   int64H(b.handleManageCourtsCancelAbort),
 
 		// ── New-game wizard ───────────────────────────────────────────────────────
 		"select_group": func(ctx context.Context, cb *tgbotapi.CallbackQuery, rawID string) {

--- a/cmd/telegram/telegram/game_manage_handlers.go
+++ b/cmd/telegram/telegram/game_manage_handlers.go
@@ -408,6 +408,7 @@ func (b *Bot) handleManageCourtsToggle(ctx context.Context, cb *tgbotapi.Callbac
 }
 
 // handleManageCourtsConfirm confirms the court selection and updates the game.
+// When courts being removed have active Eversports bookings, shows a cancel-or-back prompt first.
 func (b *Bot) handleManageCourtsConfirm(ctx context.Context, cb *tgbotapi.CallbackQuery, gameID int64) {
 	lz := b.userLocalizer(cb.From.LanguageCode)
 
@@ -437,6 +438,40 @@ func (b *Bot) handleManageCourtsConfirm(ctx context.Context, cb *tgbotapi.Callba
 		return // checkManageAdmin already answered the callback
 	}
 
+	// Pre-flight: check for active bookings on courts that are being removed.
+	removedCourts := courtsBeingRemoved(game.Courts, courts)
+	if len(removedCourts) > 0 {
+		bookings, err := b.client.ListActiveCourtBookings(ctx, gameID, removedCourts)
+		if err != nil {
+			slog.Error("handleManageCourtsConfirm: list active bookings", "err", err, "game_id", gameID)
+			b.answerCallback(cb.ID, "")
+			b.sendText(cb.Message.Chat.ID, lz.T(i18n.MsgSomethingWentWrong), nil)
+			return
+		}
+		if len(bookings) > 0 {
+			// Collect unique booked labels for the prompt.
+			seen := make(map[string]bool)
+			var bookedLabels []string
+			for _, bk := range bookings {
+				if !seen[bk.CourtLabel] {
+					seen[bk.CourtLabel] = true
+					bookedLabels = append(bookedLabels, bk.CourtLabel)
+				}
+			}
+			promptState := &manageCourtsCancelPromptState{
+				gameID:       gameID,
+				groupID:      game.ChatID,
+				newCourts:    courts,
+				bookedLabels: bookedLabels,
+				venueCourts:  state.venueCourts,
+			}
+			b.pendingManageCourtsCancelPrompt.Store(cb.Message.Chat.ID, promptState)
+			b.answerCallback(cb.ID, "")
+			b.renderCourtCancelPrompt(cb.Message.Chat.ID, cb.Message.MessageID, promptState, lz)
+			return
+		}
+	}
+
 	b.pendingManageCourtsToggle.Delete(cb.Message.Chat.ID)
 	b.answerCallback(cb.ID, "")
 
@@ -450,6 +485,140 @@ func (b *Bot) handleManageCourtsConfirm(ctx context.Context, cb *tgbotapi.Callba
 
 	b.scheduleGameMessageEdit(gameID)
 	b.sendText(cb.Message.Chat.ID, lz.Tf(i18n.MsgCourtsUpdated, courts), nil)
+}
+
+// courtsBeingRemoved returns court labels present in currentCSV but not in newCSV (multiset diff).
+func courtsBeingRemoved(currentCSV, newCSV string) []string {
+	current := splitCSV(currentCSV)
+	incoming := splitCSV(newCSV)
+	incomingCount := make(map[string]int, len(incoming))
+	for _, c := range incoming {
+		incomingCount[c]++
+	}
+	var removed []string
+	for _, c := range current {
+		if incomingCount[c] > 0 {
+			incomingCount[c]--
+		} else {
+			removed = append(removed, c)
+		}
+	}
+	return removed
+}
+
+// renderCourtCancelPrompt edits the message to show the cancellation confirmation prompt.
+func (b *Bot) renderCourtCancelPrompt(chatID int64, messageID int, state *manageCourtsCancelPromptState, lz *i18n.Localizer) {
+	labels := strings.Join(state.bookedLabels, ", ")
+	var text string
+	if len(state.bookedLabels) == 1 {
+		text = lz.Tf(i18n.MsgCourtCancelPromptSingle, labels)
+	} else {
+		text = lz.Tf(i18n.MsgCourtCancelPromptMulti, labels)
+	}
+
+	keyboard := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(
+				lz.T(i18n.BtnCourtCancelConfirm),
+				fmt.Sprintf("manage_courts_cancel_confirm:%d", state.gameID),
+			),
+		),
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(
+				lz.T(i18n.BtnCourtCancelAbort),
+				fmt.Sprintf("manage_courts_cancel_abort:%d", state.gameID),
+			),
+		),
+	)
+	edit := tgbotapi.NewEditMessageText(chatID, messageID, text)
+	edit.ParseMode = "Markdown"
+	edit.ReplyMarkup = &keyboard
+	b.api.Send(edit) //nolint:errcheck
+}
+
+// handleManageCourtsCancelConfirm cancels active bookings for removed courts then updates courts.
+func (b *Bot) handleManageCourtsCancelConfirm(ctx context.Context, cb *tgbotapi.CallbackQuery, gameID int64) {
+	lz := b.userLocalizer(cb.From.LanguageCode)
+
+	raw, ok := b.pendingManageCourtsCancelPrompt.Load(cb.Message.Chat.ID)
+	if !ok {
+		b.answerCallback(cb.ID, lz.T(i18n.MsgSessionExpired))
+		return
+	}
+	state := raw.(*manageCourtsCancelPromptState)
+	if state.gameID != gameID {
+		b.answerCallback(cb.ID, lz.T(i18n.MsgSessionExpired))
+		return
+	}
+
+	isAdmin, err := b.isAdminInGroup(cb.From.ID, state.groupID)
+	if err != nil {
+		slog.Error("handleManageCourtsCancelConfirm: check admin", "err", err, "user_id", cb.From.ID, "group_id", state.groupID)
+		b.answerCallback(cb.ID, lz.T(i18n.MsgFailedVerifyPermissions))
+		return
+	}
+	if !isAdmin {
+		b.answerCallback(cb.ID, lz.T(i18n.MsgLostAdminAccess))
+		return
+	}
+
+	b.pendingManageCourtsCancelPrompt.Delete(cb.Message.Chat.ID)
+	b.pendingManageCourtsToggle.Delete(cb.Message.Chat.ID)
+	b.answerCallback(cb.ID, "")
+
+	canceledLabels, failed, err := b.client.UpdateCourtsAndCancelBookings(ctx, gameID, state.groupID, state.newCourts, actorDisplayFrom(cb.From), cb.From.ID)
+	if err != nil {
+		slog.Error("handleManageCourtsCancelConfirm: update+cancel", "err", err, "game_id", gameID)
+		b.sendText(cb.Message.Chat.ID, lz.T(i18n.MsgFailedUpdateCourts), nil)
+		return
+	}
+
+	slog.Info("Courts updated with booking cancellation", "game_id", gameID, "courts", state.newCourts,
+		"canceled", canceledLabels, "failed", len(failed))
+
+	b.scheduleGameMessageEdit(gameID)
+
+	if len(failed) > 0 {
+		var failedLabels []string
+		for _, f := range failed {
+			failedLabels = append(failedLabels, f.Court)
+		}
+		b.sendText(cb.Message.Chat.ID, lz.Tf(i18n.MsgCourtCancelPartial, state.newCourts, strings.Join(failedLabels, ", ")), nil)
+		return
+	}
+	b.sendText(cb.Message.Chat.ID, lz.Tf(i18n.MsgCourtCancelSuccess, state.newCourts), nil)
+}
+
+// handleManageCourtsCancelAbort discards the cancellation prompt and returns to the court-toggle picker.
+func (b *Bot) handleManageCourtsCancelAbort(ctx context.Context, cb *tgbotapi.CallbackQuery, gameID int64) {
+	lz := b.userLocalizer(cb.From.LanguageCode)
+
+	raw, ok := b.pendingManageCourtsCancelPrompt.Load(cb.Message.Chat.ID)
+	if !ok {
+		b.answerCallback(cb.ID, lz.T(i18n.MsgSessionExpired))
+		return
+	}
+	state := raw.(*manageCourtsCancelPromptState)
+	if state.gameID != gameID {
+		b.answerCallback(cb.ID, lz.T(i18n.MsgSessionExpired))
+		return
+	}
+
+	b.pendingManageCourtsCancelPrompt.Delete(cb.Message.Chat.ID)
+	b.answerCallback(cb.ID, "")
+
+	// Restore toggle state so the admin can adjust the selection.
+	selected := make(map[string]bool)
+	for _, c := range splitCSV(state.newCourts) {
+		selected[c] = true
+	}
+	toggleState := &manageCourtsToggleState{
+		gameID:         gameID,
+		venueCourts:    state.venueCourts,
+		selectedCourts: selected,
+	}
+	b.pendingManageCourtsToggle.Store(cb.Message.Chat.ID, toggleState)
+	b.renderManageCourtsKeyboard(cb.Message.Chat.ID, cb.Message.MessageID, toggleState, lz)
 }
 
 // handleManagePublish publishes an unpublished game from the manage menu.

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -310,6 +310,18 @@ const (
 	// Args: %d = suggested default
 	MsgVenueCredAskMaxCourts = "msg.venue_cred_ask_max_courts"
 
+	// Court cancellation confirmation (inline toggle UI — admin removes a court with active booking)
+	// MsgCourtCancelPromptSingle: Args: %s = court label
+	MsgCourtCancelPromptSingle = "msg.court_cancel_prompt_single"
+	// MsgCourtCancelPromptMulti: Args: %s = comma-separated court labels
+	MsgCourtCancelPromptMulti = "msg.court_cancel_prompt_multi"
+	BtnCourtCancelConfirm     = "btn.court_cancel_confirm"
+	BtnCourtCancelAbort       = "btn.court_cancel_abort"
+	// MsgCourtCancelSuccess: Args: %s = final courts string
+	MsgCourtCancelSuccess = "msg.court_cancel_success"
+	// MsgCourtCancelPartial: Args: %s = final courts string, %s = failed court labels
+	MsgCourtCancelPartial = "msg.court_cancel_partial"
+
 	// Publish-game UX
 	BtnPublishGame = "btn.publish_game"
 	// MsgGamePublished: shown as callback toast on success
@@ -663,6 +675,14 @@ var translations = map[Lang]map[string]string{
 		SchedAutoBookingCredExhausted: "⚠️ Auto-booking for *%s*: all credentials exhausted. Booked %d of %d courts. Please book the remaining courts manually.",
 		SchedAutoBookingNoCredentials: "⚠️ Auto-booking for *%s* skipped: no usable credentials available. Add credentials or wait for the cooldown to expire.",
 
+		// Court cancellation confirmation
+		MsgCourtCancelPromptSingle: "Court *%s* has an active booking. To remove it the booking must be cancelled.\n\nProceed?",
+		MsgCourtCancelPromptMulti:  "Courts *%s* have active bookings. To remove them the bookings must be cancelled.\n\nProceed?",
+		BtnCourtCancelConfirm:      "Cancel booking & remove",
+		BtnCourtCancelAbort:        "← Back to selection",
+		MsgCourtCancelSuccess:      "Booking(s) cancelled. Courts updated to: %s ✓",
+		MsgCourtCancelPartial:      "Courts updated to: %s, but failed to cancel bookings for: %s",
+
 		// Publish-game UX
 		BtnPublishGame:                   "📢 Publish",
 		MsgGamePublished:                 "Game published ✓",
@@ -953,6 +973,14 @@ var translations = map[Lang]map[string]string{
 		SchedAutoBookingCredExhausted: "⚠️ Automatische Buchung für *%s*: Alle Konten ausgeschöpft. %d von %d Plätzen gebucht. Bitte die restlichen Plätze manuell buchen.",
 		SchedAutoBookingNoCredentials: "⚠️ Automatische Buchung für *%s* übersprungen: Keine verwendbaren Konten verfügbar. Füge Konten hinzu oder warte auf das Ende der Abklingzeit.",
 
+		// Court cancellation confirmation
+		MsgCourtCancelPromptSingle: "Platz *%s* hat eine aktive Buchung. Um ihn zu entfernen, muss die Buchung storniert werden.\n\nFortfahren?",
+		MsgCourtCancelPromptMulti:  "Plätze *%s* haben aktive Buchungen. Um sie zu entfernen, müssen die Buchungen storniert werden.\n\nFortfahren?",
+		BtnCourtCancelConfirm:      "Buchung stornieren & entfernen",
+		BtnCourtCancelAbort:        "← Zurück zur Auswahl",
+		MsgCourtCancelSuccess:      "Buchung(en) storniert. Plätze aktualisiert auf: %s ✓",
+		MsgCourtCancelPartial:      "Plätze aktualisiert auf: %s, aber Buchungen konnten nicht storniert werden für: %s",
+
 		// Publish-game UX
 		BtnPublishGame:                   "📢 Veröffentlichen",
 		MsgGamePublished:                 "Spiel veröffentlicht ✓",
@@ -1242,6 +1270,14 @@ var translations = map[Lang]map[string]string{
 		SchedAutoBookingCredError:     "⚠️ Автобронирование для *%s*: аккаунт *%s* вернул ошибку:\n%s\n\nАккаунт не будет использоваться в течение %s.",
 		SchedAutoBookingCredExhausted: "⚠️ Автобронирование для *%s*: все аккаунты исчерпаны. Забронировано %d из %d кортов. Пожалуйста, забронируйте оставшиеся корты вручную.",
 		SchedAutoBookingNoCredentials: "⚠️ Автобронирование для *%s* пропущено: нет доступных аккаунтов. Добавьте аккаунты или подождите окончания периода блокировки.",
+
+		// Court cancellation confirmation
+		MsgCourtCancelPromptSingle: "Корт *%s* имеет активное бронирование. Для его удаления необходимо отменить бронирование.\n\nПродолжить?",
+		MsgCourtCancelPromptMulti:  "Корты *%s* имеют активные бронирования. Для их удаления необходимо отменить бронирования.\n\nПродолжить?",
+		BtnCourtCancelConfirm:      "Отменить бронирование и удалить",
+		BtnCourtCancelAbort:        "← Назад к выбору",
+		MsgCourtCancelSuccess:      "Бронирование(я) отменено. Корты обновлены: %s ✓",
+		MsgCourtCancelPartial:      "Корты обновлены: %s, но не удалось отменить бронирования для: %s",
 
 		// Publish-game UX
 		BtnPublishGame:                   "📢 Опубликовать",


### PR DESCRIPTION
When an admin removes courts via the inline toggle UI, the bot now checks for active bookings on the removed courts and shows a two-step confirmation prompt